### PR TITLE
Support python requests keyword arguments when making remote calls

### DIFF
--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -21,7 +21,7 @@ import requests
 def SalesforceLogin(
         username=None, password=None, security_token=None,
         organizationId=None, sandbox=False, sf_version=DEFAULT_API_VERSION,
-        proxies=None, session=None, client_id=None):
+        session=None, client_id=None, timeout=60, **kwargs):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
     the domain of the instance of Salesforce to use for the session.
@@ -42,6 +42,11 @@ def SalesforceLogin(
                  enables the use of requets Session features not otherwise
                  exposed by simple_salesforce.
     * client_id -- the ID of this client
+    * timeout -- How long to wait for the server to send data before giving
+                 up, as a float, or a `(connect timeout, read timeout)` tuple.
+                 (default 60)
+
+    Keyword Args: Parameters passed down to requests.post method
     """
 
     soap_url = 'https://{domain}.salesforce.com/services/Soap/u/{sf_version}'
@@ -144,9 +149,10 @@ def SalesforceLogin(
         'charset': 'UTF-8',
         'SOAPAction': 'login'
     }
+    login_soap_request_headers.update(kwargs.pop('headers', dict()))
     response = (session or requests).post(
-        soap_url, login_soap_request_body, headers=login_soap_request_headers,
-        proxies=proxies)
+        url=soap_url, data=login_soap_request_body, headers=login_soap_request_headers,
+        timeout=timeout, **kwargs)
 
     if response.status_code != 200:
         except_code = getUniqueElementValueFromXmlString(

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -31,7 +31,8 @@ from simple_salesforce.api import (
     SalesforceRefusedRequest,
     SalesforceResourceNotFound,
     SalesforceGeneralError,
-    SFType
+    SFType,
+    RequestBase
 )
 
 
@@ -563,7 +564,7 @@ class TestSalesforce(unittest.TestCase):
 
         with patch('simple_salesforce.api.logger.warning') as mock_log:
             client = Salesforce(session_id=tests.SESSION_ID,
-                instance_url=tests.SERVER_URL, session=session, proxies={})
+                                instance_url=tests.SERVER_URL, session=session, proxies={})
             self.assertIn('ignoring proxies', mock_log.call_args[0][0])
             self.assertIs(tests.PROXIES, client.session.proxies)
 
@@ -575,12 +576,14 @@ class TestExceptionHandler(unittest.TestCase):
         self.mockresult = Mock()
         self.mockresult.url = 'http://www.example.com/'
         self.mockresult.json.return_value = 'Example Content'
+        self.mixin = RequestBase()
+        self.exec_handler = self.mixin._exception_handler
 
     def test_multiple_records_returned(self):
         """Test multiple records returned (a 300 code)"""
         self.mockresult.status_code = 300
         with self.assertRaises(SalesforceMoreThanOneRecord) as cm:
-            _exception_handler(self.mockresult)
+            self.exec_handler(self.mockresult)
 
         self.assertEqual(str(cm.exception), (
             'More than one record for '
@@ -590,7 +593,7 @@ class TestExceptionHandler(unittest.TestCase):
         """Test a malformed request (400 code)"""
         self.mockresult.status_code = 400
         with self.assertRaises(SalesforceMalformedRequest) as cm:
-            _exception_handler(self.mockresult)
+            self.exec_handler(self.mockresult)
 
         self.assertEqual(str(cm.exception), (
             'Malformed request '
@@ -600,7 +603,7 @@ class TestExceptionHandler(unittest.TestCase):
         """Test an expired session (401 code)"""
         self.mockresult.status_code = 401
         with self.assertRaises(SalesforceExpiredSession) as cm:
-            _exception_handler(self.mockresult)
+            self.exec_handler(self.mockresult)
 
         self.assertEqual(str(cm.exception), (
             'Expired session for '
@@ -610,7 +613,7 @@ class TestExceptionHandler(unittest.TestCase):
         """Test a refused request (403 code)"""
         self.mockresult.status_code = 403
         with self.assertRaises(SalesforceRefusedRequest) as cm:
-            _exception_handler(self.mockresult)
+            self.exec_handler(self.mockresult)
 
         self.assertEqual(str(cm.exception), (
             'Request refused for '
@@ -620,7 +623,8 @@ class TestExceptionHandler(unittest.TestCase):
         """Test resource not found (404 code)"""
         self.mockresult.status_code = 404
         with self.assertRaises(SalesforceResourceNotFound) as cm:
-            _exception_handler(self.mockresult, 'SpecialContacts')
+            self.mixin.name = 'SpecialContacts'
+            self.exec_handler(self.mockresult)
 
         self.assertEqual(str(cm.exception), (
             'Resource SpecialContacts Not'
@@ -630,8 +634,62 @@ class TestExceptionHandler(unittest.TestCase):
         """Test an error code that is otherwise not caught"""
         self.mockresult.status_code = 500
         with self.assertRaises(SalesforceGeneralError) as cm:
-            _exception_handler(self.mockresult)
+            self.exec_handler(self.mockresult)
 
         self.assertEqual(str(cm.exception), (
             'Error Code 500. Response content'
             ': Example Content'))
+
+    def test_deprecated_exception_handler(self):
+        """Test calling deprecated exception handler"""
+        self.mockresult.status_code = 404
+        resource_name = 'SpecialContacts'
+        with self.assertRaises(SalesforceResourceNotFound) as exception:
+            _exception_handler(result=self.mockresult, name=resource_name)
+        self.assertEqual(exception.exception.status, 404)
+        self.assertEqual(exception.exception.resource_name, resource_name)
+
+
+class TestRequestMixin(unittest.TestCase):
+    def setUp(self):
+        self.mock_resp = Mock()
+        self.mock_resp.status_code = 200
+        mock_sess = Mock()
+        mock_sess.request.return_value = self.mock_resp
+        self.req_base = RequestBase(session=mock_sess)
+        self.mock_req = mock_sess.request
+
+    def test_default_init(self):
+        inst = RequestBase()
+        self.assertIsInstance(inst.session, requests.Session)
+        self.assertEqual(inst.name, "")
+        self.assertEqual(inst.session_id, "sessionId")
+
+    def test_init_with_session(self):
+        sess = requests.Session()
+        inst = RequestBase(session=sess)
+        self.assertIs(inst.session, sess)
+
+    def test_make_request(self):
+        self.req_base.session_id = "MyVeryCrypticSessionIDASDF"
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + self.req_base.session_id,
+            'X-PrettyPrint': '1'
+        }
+        rsp = self.req_base._call_salesforce(method='GET', url='http//remote.host')
+        self.assertEqual(rsp, self.mock_resp)
+        self.mock_req.assert_called_once_with(method='GET', url='http//remote.host',
+                                              headers=headers, timeout=60)
+
+    def test_error_request(self):
+        with self.assertRaises(SalesforceMalformedRequest):
+            self.mock_resp.status_code = 400
+            self.req_base._call_salesforce(method='GET', url='http//remote.host')
+
+
+
+
+
+
+

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -12,18 +12,17 @@ try:
     # Python 2.6/2.7
     import httplib as http
     from urlparse import urlparse
-    from mock import Mock, patch
+    from mock import Mock, patch, ANY
 except ImportError:
     # Python 3
     import http.client as http
-    from unittest.mock import Mock, patch
+    from unittest.mock import Mock, patch, ANY
     from urllib.parse import urlparse
 
 from simple_salesforce import tests
 from simple_salesforce.login import (
     SalesforceLogin, SalesforceAuthenticationFailed
 )
-
 
 
 class TestSalesforceLogin(unittest.TestCase):
@@ -80,3 +79,18 @@ class TestSalesforceLogin(unittest.TestCase):
                 sandbox=True
             )
         self.assertTrue(self.mockrequest.post.called)
+
+    def test_requests_args(self):
+        mock_sess = Mock()
+        mock_sess.post.return_value = Mock(**{'status_code': 200})
+        proxies = dict(https='https://my.host.proxy')
+        with patch('simple_salesforce.login.getUniqueElementValueFromXmlString') as xml_patch:
+            xml_patch.return_value = ""
+            SalesforceLogin(
+                session=mock_sess,
+                username='foo@bar.com',
+                password='password',
+                security_token='token',
+                proxies=proxies
+            )
+            mock_sess.post.assert_called_once_with(url=ANY, data=ANY, headers=ANY, proxies=proxies, timeout=60)


### PR DESCRIPTION
Since this library is heavily dependent on `python requests` for making remote calls, it is necessary to pass down parameters such as `timeout` and `header` to requests methods.

This PR is related to #148
